### PR TITLE
The owner_id should be added from the demos themselves

### DIFF
--- a/notebooks/resources/utils.py
+++ b/notebooks/resources/utils.py
@@ -191,7 +191,6 @@ def create_test_collection() -> CollectionClient:
                 temporal=TemporalExtent([start_date, stop_date]),
             ),
         ),
-        owner_id=os.environ.get("RSPY_HOST_USER", None),
     )
     response.raise_for_status()
 


### PR DESCRIPTION
The owner_id should be set for rs_client from the demos themselves, and not from the utils.py. 