### PR TITLE
RSPY-596 - Update to stac-browser 3.3.0

### DIFF
--- a/local-mode/docker-compose.yml
+++ b/local-mode/docker-compose.yml
@@ -282,13 +282,19 @@ services:
     depends_on:
       - rs-server-adgs
     environment:
-      OIDC_ENDPOINT: https://iam.dev-rspy.esa-copernicus.eu
-      OIDC_REALM: rspy
-      PUBLIC_CLIENT_ID: fastapi_public
+      SB_authConfig: |
+            {
+              "type": "openIdConnect",
+              "openIdConnectUrl": "https://iam.dev-rspy.esa-copernicus.eu/realms/rspy/.well-known/openid-configuration",
+              "oidcConfig": {
+                "client_id": "fastapi_public"
+              }
+            }
       SB_allowExternalAccess: false
       SB_historyMode: history
       SB_catalogUrl: http://127.0.0.1:8001
       SB_detectLocaleFromBrowser: true
+      SB_socialSharing: email,bsky,mastodon
 
   # STAC browser on rs-server-cadip
   stac-browser-cadip:
@@ -299,13 +305,19 @@ services:
     depends_on:
       - rs-server-cadip
     environment:
-      OIDC_ENDPOINT: https://iam.dev-rspy.esa-copernicus.eu
-      OIDC_REALM: rspy
-      PUBLIC_CLIENT_ID: fastapi_public
+      SB_authConfig: |
+            {
+              "type": "openIdConnect",
+              "openIdConnectUrl": "https://iam.dev-rspy.esa-copernicus.eu/realms/rspy/.well-known/openid-configuration",
+              "oidcConfig": {
+                "client_id": "fastapi_public"
+              }
+            }
       SB_allowExternalAccess: false
       SB_historyMode: history
       SB_catalogUrl: http://127.0.0.1:8002
       SB_detectLocaleFromBrowser: true
+      SB_socialSharing: email,bsky,mastodon
 
   # STAC browser on rs-server-catalog
   stac-browser-catalog:
@@ -316,13 +328,19 @@ services:
     depends_on:
       - rs-server-catalog
     environment:
-      OIDC_ENDPOINT: https://iam.dev-rspy.esa-copernicus.eu
-      OIDC_REALM: rspy
-      PUBLIC_CLIENT_ID: fastapi_public
+      SB_authConfig: |
+            {
+              "type": "openIdConnect",
+              "openIdConnectUrl": "https://iam.dev-rspy.esa-copernicus.eu/realms/rspy/.well-known/openid-configuration",
+              "oidcConfig": {
+                "client_id": "fastapi_public"
+              }
+            }
       SB_allowExternalAccess: false
       SB_historyMode: history
       SB_catalogUrl: http://127.0.0.1:8003
       SB_detectLocaleFromBrowser: true
+      SB_socialSharing: email,bsky,mastodon
 
   catalog-db:
     container_name: catalog-db


### PR DESCRIPTION
Update to https://github.com/radiantearth/stac-browser/releases/tag/v3.3.0

Requires:
- https://github.com/RS-PYTHON/rs-server/pull/877
- https://github.com/RS-PYTHON/rs-helm/pull/91