### PR TITLE
Remove all files from S3 bucket with the given prefix, using low-level client and Content-MD5 header

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 default_language_version:
-    python: python3.11
-default_stages: [commit]
+    python: python3
+default_stages: [pre-commit]
 repos:
 
 # Basic verifications
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
     -   id: check-merge-conflict
     -   id: end-of-file-fixer
@@ -34,7 +34,7 @@ repos:
 
 # Format (isort)
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
     -   id: isort
         args: ["--profile", "black"]

--- a/notebooks/resources/prefect_utils.py
+++ b/notebooks/resources/prefect_utils.py
@@ -25,6 +25,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
+from botocore.utils import calculate_md5
 from fastapi.concurrency import run_in_threadpool
 from prefect.blocks.system import Secret
 from prefect.client.orchestration import get_client
@@ -292,6 +293,27 @@ async def s3_download_dir(
 
 
 def s3_delete(s3_prefix: str):
-    """Remove all files from S3 bucket with the given prefix"""
+    """Remove all files from S3 bucket with the given prefix, using low-level client and Content-MD5 header."""
     s3_bucket, prefix = get_s3_bucket(s3_prefix)
-    return s3_bucket._get_bucket_resource().objects.filter(Prefix=prefix).delete()
+    objects_to_delete = [
+        {"Key": obj.key}
+        for obj in s3_bucket._get_bucket_resource().objects.filter(Prefix=prefix)
+    ]
+
+    if not objects_to_delete:
+        return
+
+    # Hook to compute Content-MD5 from actual serialized body
+    def inject_md5_on_real_payload(request, **kwargs):
+        request.headers["Content-MD5"] = calculate_md5(request.body)
+
+    s3_client = s3_bucket._get_s3_client()
+    s3_client.meta.events.register(
+        "before-sign.s3.DeleteObjects",
+        inject_md5_on_real_payload,
+    )
+
+    return s3_client.delete_objects(
+        Bucket=s3_bucket.bucket_name,
+        Delete={"Objects": objects_to_delete, "Quiet": True},
+    )


### PR DESCRIPTION
Required on OVH object storage and boto3 >= 1.36.0. See https://github.com/ovh/public-cloud-roadmap/issues/763