### PR TITLE
RSPY-641 - Add CQL2 temporal operators support to rs-server-auxip

### DIFF
--- a/local-mode/config/adgs_ws_config.yaml
+++ b/local-mode/config/adgs_ws_config.yaml
@@ -137,6 +137,21 @@ adgs:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
@@ -282,6 +297,21 @@ adgs2:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:

--- a/local-mode/config/adgs_ws_config_token_module.yaml
+++ b/local-mode/config/adgs_ws_config_token_module.yaml
@@ -122,6 +122,21 @@ adgs:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
@@ -252,6 +267,21 @@ adgs2:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:


### PR DESCRIPTION
https://github.com/RS-PYTHON/rs-server/pull/1156
https://github.com/RS-PYTHON/rs-helm/pull/125
https://github.com/RS-PYTHON/rs-demo/pull/137

Add support for these CQL2 temporal operators:

```
            - "{t_before}"
            - "{t_after}"
            - "{t_meets}"
            - "{t_metby}"
            - "{t_overlaps}"
            - "{t_overlappedby}"
            - "{t_starts}"
            - "{t_startedby}"
            - "{t_during}"
            - "{t_contains}"
            - "{t_finishes}"
            - "{t_finishedby}"
            - "{t_equals}"
            - "{t_disjoint}"
            - "{t_intersects}"
```

Unfortunately pygeofilter does not support these operators:

```
    T_STARTS/T_STARTEDBY
    T_FINISHES/T_FINISHEDBY
    T_DISJOINT
```

See https://github.com/geopython/pygeofilter/issues/120