### PR TITLE
Feat/RSPY-723: composite CQL2 filters don't work in Auxip staging (mockup only)

### DIFF
--- a/notebooks/z-integration/test_search_auxip_cadip.ipynb
+++ b/notebooks/z-integration/test_search_auxip_cadip.ipynb
@@ -128,21 +128,7 @@
     "# auxip or cadip /search endpoint\n",
     "auxip = False\n",
     "cadip = False\n",
-    "endpoint = \"\"\n",
-    "\n",
-    "def ignore_search(search_properties=[]):\n",
-    "    \"\"\"\n",
-    "    Our adgs and cadip station simulators don't handle some parameters so we ignore these calls.\n",
-    "    \"\"\"\n",
-    "    # \"Too complex for adgs sim\"\n",
-    "    if auxip:\n",
-    "        if \"platform\" in search_properties:\n",
-    "            return True\n",
-    "        if search_properties == (\"constellation\", \"product:type\"):\n",
-    "            return True\n",
-    "\n",
-    "    # Don't ignore, do the call\n",
-    "    return False"
+    "endpoint = \"\""
    ]
   },
   {
@@ -163,11 +149,6 @@
     "    \"\"\"\n",
     "\n",
     "    info = f\"POST {endpoint!r} with params: {list(search_properties) + list(params.keys())}\"\n",
-    "\n",
-    "    # Ignore this call\n",
-    "    if ignore_search(search_properties):\n",
-    "        print(f\"Ignore {info}\")\n",
-    "        return None, None\n",
     "    print(f\"Call {info}\")\n",
     "\n",
     "    # Set the query parameters\n",
@@ -519,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed test_search_auxip_cadip notebook to remove the function to skip some searching configurations after modifications on ADGS mockup.