### PR TITLE
RSPY-806 - Fix CORS configuration in local mode

### DIFF
--- a/local-mode/.env
+++ b/local-mode/.env
@@ -22,7 +22,6 @@ export RSPY_HOST_CATALOG=http://rs-server-catalog:8000
 export RSPY_HOST_STAGING=http://rs-server-staging:8000
 export RSPY_HOST_DPR_SERVICE=http://rs-dpr-service:8000
 export RSPY_UAC_HOMEPAGE=http://localhost:9999/docs
-export CORS_ORIGINS="http://localhost:8101;http://localhost:8102;http://localhost:8103"
 
 # postgresql database
 export POSTGRES_USER=postgres

--- a/local-mode/docker-compose.yml
+++ b/local-mode/docker-compose.yml
@@ -30,7 +30,8 @@ services:
       - adgs-station
     env_file:
       - .env
-    # environment:
+    environment:
+       CORS_ORIGINS: http://localhost:8101
     #   RSPY_LOCAL_MODE: 0 # set to 0 to use the apikey-manager
     #   RSPY_UAC_CHECK_URL: http://apikey-manager:8000/auth/check_key # optional
     #   # OAuth2 authentication
@@ -55,7 +56,8 @@ services:
       - cadip-station
     env_file:
       - .env
-    # environment:
+    environment:
+       CORS_ORIGINS: http://localhost:8102
     #   RSPY_LOCAL_MODE: 0 # set to 0 to use the apikey-manager
     #   RSPY_UAC_CHECK_URL: http://apikey-manager:8000/auth/check_key # optional
     #   # OAuth2 authentication
@@ -79,6 +81,7 @@ services:
     env_file:
       - .env
     environment:
+      CORS_ORIGINS: http://localhost:8103
       # RSPY_LOCAL_MODE: 0 # set to 0 to use the apikey-manager
       # RSPY_UAC_CHECK_URL: http://apikey-manager:8000/auth/check_key # optional
       # RSPY_UAC_HOMEPAGE: ${RSPY_UAC_HOMEPAGE}
@@ -251,7 +254,7 @@ services:
             }
       SB_allowExternalAccess: false
       SB_historyMode: history
-      SB_catalogUrl: http://127.0.0.1:8001
+      SB_catalogUrl: http://127.0.0.1:8001/auxip
       SB_detectLocaleFromBrowser: true
       SB_socialSharing: email,bsky,mastodon
 
@@ -276,7 +279,7 @@ services:
             }
       SB_allowExternalAccess: false
       SB_historyMode: history
-      SB_catalogUrl: http://127.0.0.1:8002
+      SB_catalogUrl: http://127.0.0.1:8002/cadip
       SB_detectLocaleFromBrowser: true
       SB_socialSharing: email,bsky,mastodon
 
@@ -301,7 +304,7 @@ services:
             }
       SB_allowExternalAccess: false
       SB_historyMode: history
-      SB_catalogUrl: http://127.0.0.1:8003
+      SB_catalogUrl: http://127.0.0.1:8003/catalog
       SB_detectLocaleFromBrowser: true
       SB_socialSharing: email,bsky,mastodon
 


### PR DESCRIPTION
stac-fastapi splits on commas, not semicolons. 
rs-server currently splits on semicolons.

So right now we cannot use a single environment variables for rs-catalog (which uses stac-fastapi) and rs-auxip/cadip/prip (which use our own code) => Split environment variables to match what we do in the cluster deployment (no problem there)