### PR TITLE
sync-config-prune-missing-keys

### DIFF
--- a/local-mode/config/rs-server.yaml
+++ b/local-mode/config/rs-server.yaml
@@ -284,14 +284,8 @@ external_data_sources:
       port: 21
     authentication:
       auth_type: ftp
-      token_url: null
-      grant_type: password
-      scope: null
       username: test
       password: test
-      client_id: client_id
-      client_secret: client_secret
-      authorization: null
       ca_crt: '-----BEGIN CERTIFICATE-----
 
         MIID...
@@ -315,14 +309,8 @@ external_data_sources:
       port: 21
     authentication:
       auth_type: ftp
-      token_url: null
-      grant_type: password
-      scope: null
       username: test
       password: test
-      client_id: client_id
-      client_secret: client_secret
-      authorization: null
       ca_crt: '-----BEGIN CERTIFICATE-----
 
         MIID...
@@ -345,14 +333,6 @@ external_data_sources:
       url: https://s3.gra.io.cloud.ovh.net
     authentication:
       auth_type: s3
-      token_url: null
-      grant_type: password
-      scope: null
-      username: test
-      password: test
-      client_id: client_id
-      client_secret: client_secret
-      authorization: null
       access_key: ${access_key}
       secret_key: ${secret_key}
   cdse:
@@ -362,13 +342,5 @@ external_data_sources:
       url: https://eodata.dataspace.copernicus.eu
     authentication:
       auth_type: s3
-      token_url: null
-      grant_type: password
-      scope: null
-      username: test
-      password: test
-      client_id: client_id
-      client_secret: client_secret
-      authorization: null
       access_key: example_s3_access_key
       secret_key: example_s3_secret_key

--- a/local-mode/config/rs-server.yaml
+++ b/local-mode/config/rs-server.yaml
@@ -33,6 +33,9 @@ external_data_sources:
       client_id: client_id
       client_secret: client_secret
       authorization: Basic test
+    trusteddomains:
+    - trusted.domain1.eu
+    - trusted.domain2.eu
   adgs2:
     domain: adgs-station
     service:
@@ -273,6 +276,68 @@ external_data_sources:
       client_id: client_id
       client_secret: client_secret
       authorization: Basic test
+  pedc:
+    domain: edrs-station
+    service:
+      name: edrs
+      url: edrs-station
+      port: 21
+    authentication:
+      auth_type: ftp
+      token_url: null
+      grant_type: password
+      scope: null
+      username: test
+      password: test
+      client_id: client_id
+      client_secret: client_secret
+      authorization: null
+      ca_crt: '-----BEGIN CERTIFICATE-----
+
+        MIID...
+
+        -----END CERTIFICATE-----'
+      client_crt: '-----BEGIN CERTIFICATE-----
+
+        MIID...
+
+        -----END CERTIFICATE-----'
+      client_key: '-----BEGIN RSA PRIVATE KEY-----
+
+        MIID...
+
+        -----END RSA PRIVATE KEY-----'
+  bedc:
+    domain: edrs-station
+    service:
+      name: edrs
+      url: edrs-station
+      port: 21
+    authentication:
+      auth_type: ftp
+      token_url: null
+      grant_type: password
+      scope: null
+      username: test
+      password: test
+      client_id: client_id
+      client_secret: client_secret
+      authorization: null
+      ca_crt: '-----BEGIN CERTIFICATE-----
+
+        MIID...
+
+        -----END CERTIFICATE-----'
+      client_crt: '-----BEGIN CERTIFICATE-----
+
+        MIID...
+
+        -----END CERTIFICATE-----'
+      client_key: '-----BEGIN RSA PRIVATE KEY-----
+
+        MIID...
+
+        -----END RSA PRIVATE KEY-----'
   s3test:
     domain: s3.gra.io.cloud.ovh.net
     service:
@@ -290,3 +355,20 @@ external_data_sources:
       authorization: null
       access_key: ${access_key}
       secret_key: ${secret_key}
+  cdse:
+    domain: eodata.dataspace.copernicus.eu
+    service:
+      name: s3
+      url: https://eodata.dataspace.copernicus.eu
+    authentication:
+      auth_type: s3
+      token_url: null
+      grant_type: password
+      scope: null
+      username: test
+      password: test
+      client_id: client_id
+      client_secret: client_secret
+      authorization: null
+      access_key: example_s3_access_key
+      secret_key: example_s3_secret_key


### PR DESCRIPTION
prune keys that no longer exist in the rs-server configuration files
update rs-server.template.yaml to solve 
Missing from rs-server: 'cdse'
Missing from rs-server: 'pedc'
Missing from rs-server: 'bedc'
Missing from rs-server: 'adgs.trusteddomains'