### PR TITLE
local-reverse-proxy

### DIFF
--- a/local-mode/docker-compose.yml
+++ b/local-mode/docker-compose.yml
@@ -554,6 +554,8 @@ services:
       - rs-server-prip
       - rs-server-edrs
       - rs-server-catalog
+      - rs-server-staging
+      - rs-dpr-service
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
 

--- a/local-mode/docker-compose.yml
+++ b/local-mode/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/rs-python/rs-server-frontend:latest
     container_name: rs-server-frontend
     ports:
-      - 8000:8000
+      - 8007:8000
     env_file:
       - .env
 
@@ -541,6 +541,21 @@ services:
       SB_catalogUrl: http://127.0.0.1:8006/edrs
       SB_detectLocaleFromBrowser: true
       SB_socialSharing: email,bsky,mastodon
+
+  rs-local-gateway:
+    image: nginx:alpine
+    container_name: rs-local-gateway
+    ports:
+      - 8000:80
+    depends_on:
+      - rs-server-frontend
+      - rs-server-adgs
+      - rs-server-cadip
+      - rs-server-prip
+      - rs-server-edrs
+      - rs-server-catalog
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
 
   ###########
   # PREFECT #

--- a/local-mode/nginx.conf
+++ b/local-mode/nginx.conf
@@ -81,7 +81,7 @@ http {
     location = /staging {
       return 301 /staging/;
     }
- 
+
     location /staging/ {
       proxy_pass http://rs-server-staging:8000/staging/;
       proxy_set_header Host $host;
@@ -91,7 +91,7 @@ http {
     location = /dpr {
       return 301 /dpr/;
     }
- 
+
     location /dpr/ {
       proxy_pass http://rs-dpr-service:8000/dpr/;
       proxy_set_header Host $host;

--- a/local-mode/nginx.conf
+++ b/local-mode/nginx.conf
@@ -77,5 +77,25 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    location = /staging {
+      return 301 /staging/;
+    }
+ 
+    location /staging/ {
+      proxy_pass http://rs-server-staging:8000/staging/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /dpr {
+      return 301 /dpr/;
+    }
+ 
+    location /dpr/ {
+      proxy_pass http://rs-dpr-service:8000/dpr/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
   }
 }

--- a/local-mode/nginx.conf
+++ b/local-mode/nginx.conf
@@ -1,0 +1,81 @@
+events {}
+
+http {
+  server {
+    listen 80;
+
+    # Swagger UI and OpenAPI served by rs-server-frontend
+    location = /docs {
+      proxy_pass http://rs-server-frontend:8000/docs;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /docs/ {
+      proxy_pass http://rs-server-frontend:8000/docs/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /openapi.json {
+      proxy_pass http://rs-server-frontend:8000/openapi.json;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Route ADGS backend under /auxip
+    location = /auxip {
+      return 301 /auxip/;
+    }
+
+    location /auxip/ {
+      proxy_pass http://rs-server-adgs:8000/auxip/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Route CADIP backend under /cadip
+    location = /cadip {
+      return 301 /cadip/;
+    }
+
+    location /cadip/ {
+      proxy_pass http://rs-server-cadip:8000/cadip/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Route PRIP backend under /prip
+    location = /prip {
+      return 301 /prip/;
+    }
+
+    location /prip/ {
+      proxy_pass http://rs-server-prip:8000/prip/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Route EDRS backend under /edrs
+    location = /edrs {
+      return 301 /edrs/;
+    }
+
+    location /edrs/ {
+      proxy_pass http://rs-server-edrs:8000/edrs/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Route Catalog backend under /catalog
+    location = /catalog {
+      return 301 /catalog/;
+    }
+
+    location /catalog/ {
+      proxy_pass http://rs-server-catalog:8000/catalog/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+}


### PR DESCRIPTION
Local NGINX reverse proxy that acts as a ingress emulator, reproducing the cluster’s single-origin, path-based routing so Swagger and browser requests behave (hopefully) the same as in Kubernetes.


The Swagger UI served by rs-server-frontend on localhost could not execute "Try it out" calls like /auxip/search in local mode because the frontend container does not proxy requests and there is no ingress; therefore /auxip/... was sent to the frontend itself and returned 404. 
The fix was to mimic the cluster ingress locally by introducing an Nginx reverse proxy on localhost that routes /docs and openapi.json to rs-server-frontend and routes backend paths like /auxip, /cadip, /prip, /edrs, /catalog, and /staging to their respective services, while moving the frontend to another port; this restores same‑origin behavior and makes Swagger “Try it out” work locally.
