### PR TITLE
RSPY-1043 - Create a new Dask image with only CPM

### DIFF
--- a/notebooks/resources/dask_utils.py
+++ b/notebooks/resources/dask_utils.py
@@ -424,6 +424,22 @@ def init_dask_cluster_mockup(
     )
 
 
+def init_dask_cluster_cpm(
+    *args,
+    image=("ghcr.io/rs-python/dask/cpm/k8s:latest"),
+    cluster_label="dask-cpm",
+    **kwargs,
+):
+    return init_dask_cluster_eopf(
+        *args,
+        local_mode_address=None,
+        local_mode_address_public=None,
+        image=image,
+        cluster_label=cluster_label,
+        **kwargs,
+    )
+
+
 def init_dask_cluster_l0(
     *args,
     image=(


### PR DESCRIPTION
New Dask image to run latest version of cpm for SAFE to ZARR product conversion:

```python
def init_dask_cluster_cpm(
    *args,
    image=("ghcr.io/rs-python/dask/cpm/k8s:latest"),
    cluster_label="dask-cpm",
    **kwargs,
):
    return init_dask_cluster_eopf(
        *args,
        local_mode_address=None,
        local_mode_address_public=None,
        image=image,
        cluster_label=cluster_label,
        **kwargs,
    )

```

Pull requests:
- https://github.com/RS-PYTHON/rs-workflow-env/pull/84
- https://github.com/RS-PYTHON/rs-demo/pull/300