### PR TITLE
RSPY-1108: Problems in the CI/CD to build the Jupyter docker images

### DIFF
--- a/.github/workflows/run_demos.yml
+++ b/.github/workflows/run_demos.yml
@@ -91,3 +91,21 @@ jobs:
           name: notebook-outputs
           path: local-mode/notebook-outputs/
           if-no-files-found: ignore
+
+  trigger-rs-workflow-env:
+    runs-on: ubuntu-latest
+    name: Trigger rs-workflow-env # to build the jupyter image for cluster mode with the latest rs-demo changes
+    if: (github.event_name == 'push') && (github.ref_name == 'develop') # Only when we push to develop
+    steps:
+      - name: Trigger rs-workflow-env
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4
+        with:
+          workflow: build-jupyter.yml
+          repo: RS-PYTHON/rs-workflow-env
+          ref: develop
+          inputs: '{
+            "build_base_image": false
+            }'
+          token: '${{ secrets.TRIGGER_WORKFLOWS }}'
+          wait-for-completion: true
+          wait-timeout-seconds: 3600


### PR DESCRIPTION
How these changes fix the Jira https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1108: 

  * The docker tag for the jupyter base image is not `hub-xxx-pyzzz-vn` anymore, but instead it is the branch name. So we don't have any more conflicts between branches. (fixes problem 1)
  * The jupyter image for cluster mode (built by rs-workflow-env) needs the rs-client-libraries wheel. Instead of downloading it from the rs-client-libraries repository ci/cd, it now checkouts the rs-client-libraries source code and builds the wheel itself. This way, the rs-client-libraries ci/cd does not have to trigger the rs-workflow-env ci/cd anymore. (fixes problem 2)
  * After rs-workflow-env builds the base jupyter image, now it triggers the rs-client-libraries ci/cd to build the jupyter image for local mode. (fixes problem 2)
    * If rs-client-libraries does not have the same branch name as in rs-workflow-env, then the develop branch of rs-client-libraries is triggered, but we tell it to use the docker tags with the same branch name as rs-workflow-env. See `force_docker_tags` and `force_docker_final_tags`. (fixes problem 3)

About the comment
> So maybe the rs-workflow-env ci/cd should always trigger the rs-client-libraries ci/cd after building base-notebook.

> Actually it's too dangerous: if the rs-client-libraries ci/cd is already running, the two runs would overwrite each other's docker images and the result would be unstable.

Before rs-workflow-env triggers rs-client-libraries, it cancels active workflow runs with the same branch name.
